### PR TITLE
repl() force external if example requires it

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: js4shiny
 Title: Companion Package for JavaScript for Shiny Users
-Version: 0.0.24
+Version: 0.0.25
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/man/repl.Rd
+++ b/man/repl.Rd
@@ -15,6 +15,7 @@ repl(
   theme_editor = "textmate",
   autocomplete = c("css", "html"),
   render_dir = NULL,
+  options = list(),
   ...
 )
 
@@ -44,6 +45,8 @@ autocomplete here actually doesn't mean disabling all together.
 Autocomplete will still be available by pressing \code{Ctrl} + \code{space}.}
 
 \item{render_dir}{Where to render temporary files, defaults to \code{tempdir()}}
+
+\item{options}{Options passed to \code{\link[shiny:runApp]{shiny::runApp()}}.}
 
 \item{...}{Arguments passed from \code{repl_js()} to \code{repl()} or from \code{repl()} to
 \code{\link[shiny:shinyApp]{shiny::shinyApp()}}.}

--- a/tests/testthat/test-repl.R
+++ b/tests/testthat/test-repl.R
@@ -49,3 +49,22 @@ test_that("resources round trip through yaml with js4shiny::html_document_js4shi
 
   expect_equal(yaml_from_res, yaml$output[["js4shiny::html_document_js4shiny"]][c("css", "script")])
 })
+
+
+test_that("repl() and repl_example() force external browser when needed", {
+  suppressWarnings(s <- repl("bootstrap"))
+
+  expect_equal(s, repl_example("bootstrap"))
+  expect_identical(s$options$launch.browser, TRUE)
+
+  # set shiny.launch.browser to a fixed but nonsense value
+  opt <- options("shiny.launch.browser" = function() "apple")
+  s_internal <- repl("css-variables")
+  expect_equal(s_internal, repl_example("css-variables"))
+  expect_identical(s_internal$options$launch.browser(), "apple")
+  options(opt)
+})
+
+test_that("repl() warns if multiple examples are requested", {
+  expect_warning(s <- repl(c("bootstrap", "css-variables")))
+})


### PR DESCRIPTION
Opens examples that have external dependencies in an external browser, otherwise respects the current option.